### PR TITLE
Reading only segments bucket size bug

### DIFF
--- a/swift_browser_ui_frontend/src/common/conv.js
+++ b/swift_browser_ui_frontend/src/common/conv.js
@@ -460,7 +460,7 @@ export function parseDateFromNow(locale, value, t) {
 export function addSegmentContainerSize(container, containers) {
   let segments = containers.find(el => el.name === `${container.name}_segments`);
   if (segments !== undefined) {
-    container.bytes += segments.bytes;  // Add instead of overwrite
+    container.bytes += segments.bytes;
   }
 }
 

--- a/swift_browser_ui_frontend/src/common/conv.js
+++ b/swift_browser_ui_frontend/src/common/conv.js
@@ -459,8 +459,8 @@ export function parseDateFromNow(locale, value, t) {
 // container.
 export function addSegmentContainerSize(container, containers) {
   let segments = containers.find(el => el.name === `${container.name}_segments`);
-  if (segments !== undefined && container.count > 0) {
-    container.bytes = segments.bytes;
+  if (segments !== undefined) {
+    container.bytes += segments.bytes;  // Add instead of overwrite
   }
 }
 

--- a/swift_browser_ui_frontend/src/components/ContainerTable.vue
+++ b/swift_browser_ui_frontend/src/components/ContainerTable.vue
@@ -152,7 +152,6 @@ export default {
         await getSharedContainers(this.active.id, this.abortController.signal);
     },
     async getPage () {
-      console.log("getPage called");
       let offset = 0;
       let limit = this.conts?.length;
 
@@ -174,23 +173,6 @@ export default {
         }
         return "";
       };
-
-      // const sizeMap = {};
-
-      // this.conts.forEach(container => {
-      //   let baseName = container.name;
-
-      //   if (!sizeMap[baseName]) {
-      //     sizeMap[baseName] = 0;
-      //   }
-
-      //   sizeMap[baseName] += container.bytes;
-      //   console.log(`Processing: ${container.name}, Size: ${container.bytes}`);
-      // });
-
-      // console.log('Final sizeMap:', sizeMap);
-
-
 
       // Filter out segment folders for rendering
       // Map the 'accessRights' to the container if it's a shared container

--- a/swift_browser_ui_frontend/src/components/ContainerTable.vue
+++ b/swift_browser_ui_frontend/src/components/ContainerTable.vue
@@ -187,8 +187,9 @@ export default {
           sizeMap[baseName] += container.bytes;
         } else {
           if (!sizeMap[container.name]) {
-            sizeMap[container.name] = container.bytes;
+          sizeMap[container.name] = 0;
           }
+          sizeMap[container.name] += container.bytes;
         }
       });
 

--- a/swift_browser_ui_frontend/src/components/ContainerTable.vue
+++ b/swift_browser_ui_frontend/src/components/ContainerTable.vue
@@ -152,6 +152,7 @@ export default {
         await getSharedContainers(this.active.id, this.abortController.signal);
     },
     async getPage () {
+      console.log("getPage called");
       let offset = 0;
       let limit = this.conts?.length;
 
@@ -174,31 +175,27 @@ export default {
         return "";
       };
 
-      // Create a map to store the total sizes
-      const sizeMap = {};
+      // const sizeMap = {};
 
-      // Iterate through the containers to calculate sizes
-      this.conts.forEach(container => {
-        if (container.name.endsWith('_segments')) {
-          const baseName = container.name.replace('_segments', '');
-          if (!sizeMap[baseName]) {
-            sizeMap[baseName] = 0;
-          }
-          sizeMap[baseName] += container.bytes;
-        } else {
-          if (!sizeMap[container.name]) {
-          sizeMap[container.name] = 0;
-          }
-          sizeMap[container.name] += container.bytes;
-        }
-      });
+      // this.conts.forEach(container => {
+      //   let baseName = container.name;
+
+      //   if (!sizeMap[baseName]) {
+      //     sizeMap[baseName] = 0;
+      //   }
+
+      //   sizeMap[baseName] += container.bytes;
+      //   console.log(`Processing: ${container.name}, Size: ${container.bytes}`);
+      // });
+
+      // console.log('Final sizeMap:', sizeMap);
+
 
 
       // Filter out segment folders for rendering
       // Map the 'accessRights' to the container if it's a shared container
       const mappedContainers = await Promise.all(
-        this.conts.filter(cont => !cont.name.endsWith("_segments"))
-          .map(async(cont) => {
+        this.conts.map(async(cont) => {
             const sharedDetails = cont.owner ? await getAccessDetails(
               this.$route.params.project,
               cont.container,
@@ -253,7 +250,7 @@ export default {
               value: item.count,
             },
             size: {
-              value: getHumanReadableSize(sizeMap[item.name], this.locale),
+              value: getHumanReadableSize(item.bytes, this.locale),
             },
             ...(this.hideTags ? {} : {
               tags: {

--- a/swift_browser_ui_frontend/src/components/ContainerTable.vue
+++ b/swift_browser_ui_frontend/src/components/ContainerTable.vue
@@ -174,6 +174,25 @@ export default {
         return "";
       };
 
+      // Create a map to store the total sizes
+      const sizeMap = {};
+
+      // Iterate through the containers to calculate sizes
+      this.conts.forEach(container => {
+        if (container.name.endsWith('_segments')) {
+          const baseName = container.name.replace('_segments', '');
+          if (!sizeMap[baseName]) {
+            sizeMap[baseName] = 0;
+          }
+          sizeMap[baseName] += container.bytes;
+        } else {
+          if (!sizeMap[container.name]) {
+            sizeMap[container.name] = container.bytes;
+          }
+        }
+      });
+
+
       // Filter out segment folders for rendering
       // Map the 'accessRights' to the container if it's a shared container
       const mappedContainers = await Promise.all(
@@ -233,7 +252,7 @@ export default {
               value: item.count,
             },
             size: {
-              value: getHumanReadableSize(item.bytes, this.locale),
+              value: getHumanReadableSize(sizeMap[item.name], this.locale),
             },
             ...(this.hideTags ? {} : {
               tags: {

--- a/swift_browser_ui_frontend/src/components/ContainerTable.vue
+++ b/swift_browser_ui_frontend/src/components/ContainerTable.vue
@@ -177,7 +177,8 @@ export default {
       // Filter out segment folders for rendering
       // Map the 'accessRights' to the container if it's a shared container
       const mappedContainers = await Promise.all(
-        this.conts.map(async(cont) => {
+        this.conts.filter(cont => !cont.name.endsWith("_segments"))
+          .map(async(cont) => {
             const sharedDetails = cont.owner ? await getAccessDetails(
               this.$route.params.project,
               cont.container,


### PR DESCRIPTION
### Description
- The original function **overwrote** the container size with the segment size, ignoring existing bytes.


#### How to test
Tested on Allas-UI dev env as can seen from the screen shot (I allowed segments bucket to be viewed just to see the problem) the size of the normal bucket was only the size of the segments bucket even though it had files in it. 

![Screenshot from 2025-01-24 11-02-49](https://github.com/user-attachments/assets/54e0ec49-ffe8-492f-9b30-7458e44312e0)

and as can be seen here it is fixed:


![Screenshot from 2025-01-27 07-52-20](https://github.com/user-attachments/assets/7796c381-8120-43fb-b5e2-71761e9de711)


### Changes
- The `container.bytes` was set to the segment size (`segments.bytes`), which **overwrote** any existing value.
- If the container had its own objects (`bytes > 0`), their size was **discarded**, leading to a wrong total size.
- The condition `container.count > 0` prevented updating the size when the count was zero, which caused segments to be ignored for empty containers.

