### PR TITLE
5GiB limit on downloads of buckets / folders

### DIFF
--- a/CHANGELOG - ALLAS-UI.md
+++ b/CHANGELOG - ALLAS-UI.md
@@ -2,9 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
-## 2025-01-21
+## 2025-01-28
 
 ### Changed
+
+- 5GiB limit for downloads of folders / buckets
+
+## 2025-01-27
+
+### Fixed
+
+-  Segment bucket overwrite size of normal buckets bug fixed.
+
+## 2025-01-21
+
+### Fixed
 
 -  Bucket size bigger than 1TiB inconstant bug fixed.
 
@@ -19,7 +31,3 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - UI color change
-
-### Changed
-
--  Internal BETA release ready

--- a/swift_browser_ui_frontend/src/common/lang.js
+++ b/swift_browser_ui_frontend/src/common/lang.js
@@ -214,7 +214,9 @@ let default_translations = {
           "Service Worker might be down. Please refresh the page, wait a " +
           "minute, and try again. Recommended browser for use: Chrome.",
         cancel: "Download cancelled",
-        errorSizeExceeded: "Downloading buckets or folders larger than 5 GiB is currently not supported. However, single files of that size can be downloaded.",
+        errorSizeExceeded: "Downloading buckets or folders larger than 5 GiB " +
+          "is currently not supported. However, single files of that size " +
+          "can be downloaded.",
       },
       upload: {
         duplicate: "Files with the same paths are not allowed.",

--- a/swift_browser_ui_frontend/src/common/lang.js
+++ b/swift_browser_ui_frontend/src/common/lang.js
@@ -214,6 +214,7 @@ let default_translations = {
           "Service Worker might be down. Please refresh the page, wait a " +
           "minute, and try again. Recommended browser for use: Chrome.",
         cancel: "Download cancelled",
+        errorSizeExceeded: "Downloading buckets or folders larger than 5 GiB is currently not supported. However, single files of that size can be downloaded.",
       },
       upload: {
         duplicate: "Files with the same paths are not allowed.",

--- a/swift_browser_ui_frontend/src/components/CObjectTable.vue
+++ b/swift_browser_ui_frontend/src/components/CObjectTable.vue
@@ -437,7 +437,14 @@ export default {
       //automated testing creates untrusted events
       const test = eventTrusted === undefined ? false: !eventTrusted;
 
+      const MAX_DOWNLOAD_SIZE = 5 * 1024 * 1024 * 1024; // 5GiB in bytes
+
       if (object?.subfolder) {
+         // Check if folder size exceeds the limit
+         if (object.bytes > MAX_DOWNLOAD_SIZE) {
+          addErrorToastOnMain(this.$t("message.download.errorSizeExceeded", { size: "5 GiB" }));
+          return;
+        }
         const subfolderFiles = this
           .objs
           .filter((obj) => {

--- a/swift_browser_ui_frontend/src/components/CObjectTable.vue
+++ b/swift_browser_ui_frontend/src/components/CObjectTable.vue
@@ -442,7 +442,7 @@ export default {
       if (object?.subfolder) {
          // Check if folder size exceeds the limit
          if (object.bytes > MAX_DOWNLOAD_SIZE) {
-          addErrorToastOnMain(this.$t("message.download.errorSizeExceeded", { size: "5 GiB" }));
+          addErrorToastOnMain(this.$t("message.download.errorSizeExceeded"));
           return;
         }
         const subfolderFiles = this

--- a/swift_browser_ui_frontend/src/components/ContainerTable.vue
+++ b/swift_browser_ui_frontend/src/components/ContainerTable.vue
@@ -516,6 +516,16 @@ export default {
       //automated testing creates untrusted events
       const test = eventTrusted === undefined ? false : !eventTrusted;
 
+      const MAX_DOWNLOAD_SIZE = 5 * 1024 * 1024 * 1024; // 5GiB in bytes
+
+      // Find the container details to check its size
+      const containerData = this.conts.find(cont => cont.name === container);
+
+      if (containerData && containerData.bytes > MAX_DOWNLOAD_SIZE) {
+        addErrorToastOnMain(this.$t("message.download.errorSizeExceeded", { size: "5 GiB" }));
+        return;
+      }
+
       this.$store.state.socket.addDownload(
         container,
         [],

--- a/swift_browser_ui_frontend/src/components/ContainerTable.vue
+++ b/swift_browser_ui_frontend/src/components/ContainerTable.vue
@@ -522,7 +522,7 @@ export default {
       const containerData = this.conts.find(cont => cont.name === container);
 
       if (containerData && containerData.bytes > MAX_DOWNLOAD_SIZE) {
-        addErrorToastOnMain(this.$t("message.download.errorSizeExceeded", { size: "5 GiB" }));
+        addErrorToastOnMain(this.$t("message.download.errorSizeExceeded"));
         return;
       }
 


### PR DESCRIPTION
### Description

Implementation of limiting the download of buckets / folders that are bigger than 5GiB.


### Type of change

Added a condition in both `CObjectTable.vue` and `ContainerTable.vue` to check and limit the download. Also updated the CHANGELOG of ALLAS-UI

[Screencast from 2025-01-28 15-27-43.webm](https://github.com/user-attachments/assets/6421061c-041c-4e65-887f-7db3e03c2c0f)
[Screencast from 2025-01-28 15-28-54.webm](https://github.com/user-attachments/assets/7bad214a-b468-4c6a-b43b-a9677f5f72c7)
